### PR TITLE
new release endpoint + centos7 systemd service

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,20 +50,16 @@
 class consul_alerts (
   $enabled      = true,
   $binary_path  = '/usr/local/bin',
-  $version      = '0.2.0',
-  $repo_url     = 'https://github.com/AcalephStorage/consul-alerts/releases/download',
-  $arch         = $::architecture,
-  $default_url  = true,
-  $custom_url   = undef,
+  $version      = 'v0.2.0',
+  $repo_url     = 'https://github.com/AcalephStorage/consul-alerts/archive/',
+  $arch         = $::achitecture,
   $alert_addr   = '127.0.0.1:9000',
   $consul_url   = '127.0.0.1:8500',
   $data_center  = 'dc1',
   $watch_events = true,
   $watch_checks = true,
 ) {
-  #Variable validations
   validate_bool($enabled)
-  validate_bool($default_url)
   validate_bool($watch_events)
   validate_bool($watch_checks)
   validate_absolute_path($binary_path)
@@ -74,18 +70,11 @@ class consul_alerts (
   validate_string($consul_url)
   validate_string($data_center)
 
-  #Build the full download URL
-  $filename     = "consul-alerts-${version}-linux-${arch}.tar"
-  $download_url = $default_url ? {
-    false   => $custom_url,
-    default => "${repo_url}/v${version}/${filename}",
-  }
+  $download_url = "${repo_url}${version}.tar.gz"
 
-  #Download consul-alerts binary
   include ::wget
-
   exec { 'download_consul_alerts':
-    command => "wget -q --no-check-certificate $download_url -O /var/tmp/${filename}",
+    command => "wget -q --no-check-certificate ${download_url} -O /var/tmp/${filename}",
     path    => '/usr/bin:/usr/local/bin:/bin',
     unless  => "test -s /var/tmp/${filename}",
     notify  => Exec['extract_consul_alerts'],

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -58,6 +58,8 @@ class consul_alerts (
   $data_center  = 'dc1',
   $watch_events = true,
   $watch_checks = true,
+  $user         = 'consul',
+  $group        = 'consul',
 ) {
   validate_bool($enabled)
   validate_bool($watch_events)
@@ -69,6 +71,8 @@ class consul_alerts (
   validate_string($alert_addr)
   validate_string($consul_url)
   validate_string($data_center)
+  validate_string($user)
+  validate_string($group)
 
   $download_url = "${repo_url}${version}.tar.gz"
 
@@ -95,10 +99,10 @@ class consul_alerts (
     default => present,
   }
   #Build init file
-  file { '/etc/init/consul-alerts.conf':
+  file { '/usr/lib/systemd/system/consul-alerts.service':
     ensure  => $file_ensure,
     content => template('consul_alerts/initfile.erb'),
-    notify  => Service['consul-alerts'],
+    notify  => Service['consul-alerts.service'],
   }
 
   service { 'consul-alerts':
@@ -106,7 +110,7 @@ class consul_alerts (
     enable  => $enabled,
     require => [
       Exec['extract_consul_alerts'],
-      File['/etc/init/consul-alerts.conf'],
+      File['/usr/lib/systemd/system/consul-alerts.service'],
     ],
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,9 +1,9 @@
 {
   "name": "jlondon-consul_alerts",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "Justice London",
   "summary": "Puppet module to configure and install consul-alerts service",
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "source": "https://github.com/justicel/puppet-consul_alerts.git",
   "project_page": "https://github.com/justicel/puppet-consul_alerts",
   "issues_url": "https://github.com/justicel/puppet-consul_alerts/issues",
@@ -11,14 +11,12 @@
     "consul",
     "consul-alerts",
     "ops",
-    "devops",
     "monitoring",
     "centos",
-    "debian",
     "ubuntu"
   ],
   "dependencies": [
-    {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"},
+    {"name":"puppetlabs-stdlib","version_requirement":">= 4.1.0"},
     {"name":"maestrodev-wget", "version_requirement":">= 1.5.7"}
   ],
   "operatingsystem_support": [

--- a/templates/initfile.erb
+++ b/templates/initfile.erb
@@ -10,12 +10,7 @@ After=basic.target network.target
 [Service]                                          
 User=consul                                        
 Group=consul                                       
-ExecStart=/usr/local/bin/consul-alerts start \     
-  --alert-addr=<%= @alert_addr %> \                
-  --consul-addr=<%= @consul_url %> \               
-  --consul-dc=<%= @data_center %> \                
-  <% if @watch_events -%>--watch-events<% end -%> \
-  <% if @watch_checks -%> --watch-checks<% end -%> 
+ExecStart=/usr/local/bin/consul-alerts start --alert-addr=<%= @alert_addr %> --consul-addr=<%= @consul_url %> --consul-dc=<%= @data_center %> <% if @watch_events -%>--watch-events<% end -%> <% if @watch_checks -%>--watch-checks<% end -%> 
 ExecReload=/bin/kill -HUP $MAINPID                 
 KillMode=process                                   
 Restart=on-failure                                 

--- a/templates/initfile.erb
+++ b/templates/initfile.erb
@@ -2,11 +2,24 @@
 #Managed by puppet
 #Do not modify by hand
 
-start on runlevel [2345]
-stop on runlevel [016]
-respawn
-respawn limit 5 30
-
-chdir <%= @binary_path %>
-
-exec consul-alerts start --alert-addr=<%= @alert_addr %> --consul-addr=<%= @consul_url %> --consul-dc=<%= @data_center %> <% if @watch_events -%>--watch-events<% end -%><% if @watch_checks -%> --watch-checks<% end -%>
+[Unit]                                            
+Description=Consul Alerts                          
+Wants=basic.target                                 
+After=basic.target network.target                  
+                                                   
+[Service]                                          
+User=consul                                        
+Group=consul                                       
+ExecStart=/usr/local/bin/consul-alerts start \     
+  --alert-addr=<%= @alert_addr %> \                
+  --consul-addr=<%= @consul_url %> \               
+  --consul-dc=<%= @data_center %> \                
+  <% if @watch_events -%>--watch-events<% end -%> \
+  <% if @watch_checks -%> --watch-checks<% end -%> 
+ExecReload=/bin/kill -HUP $MAINPID                 
+KillMode=process                                   
+Restart=on-failure                                 
+RestartSec=42s                                     
+                                                   
+[Install]                                          
+WantedBy=multi-user.target


### PR DESCRIPTION
**Changes**
- Changes the end point used to download consul-alerts binary
- Changes service to systemd (centos 7 compatability)

**This change breaks compatibility with other OS versions due to fixes above**

**TODO:**

- [ ] add backwards compatibility with other OS versions for download and service

